### PR TITLE
Bug fix in is_true_str function

### DIFF
--- a/libyaml-core.c
+++ b/libyaml-core.c
@@ -50,7 +50,7 @@ is_true_str(const char *s, ptrdiff_t len)
 		return (strcmp("on", s) == 0 || strcmp("On", s) == 0
 			|| strcmp("ON", s) == 0);
 	case 3:
-		return (strcmp("yes", s) == 0 || strcmp("Yes", s)
+		return (strcmp("yes", s) == 0 || strcmp("Yes", s) == 0
 			|| strcmp("YES", s) == 0);
 	case 4:
 		return (strcmp("true", s) == 0 || strcmp("True", s) == 0


### PR DESCRIPTION
There was a bug in is_true_str function which caused all 3 character strings to
be parsed as true. This was due to a minor bug in the test condition. Fixes #2 